### PR TITLE
🔧 ELB의 Health Check 주기를 300초로 변경

### DIFF
--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -47,7 +47,7 @@ data "aws_ami" "ubuntu" {
 
 # was 서버(EC2) 생성
 resource "aws_instance" "compute" {
-  ami                    = data.aws_ami.ubuntu.id
+  ami                    = "ami-00e557080ac814181"
   instance_type          = "t2.micro"
   subnet_id              = var.subnet_id
   vpc_security_group_ids = [aws_security_group.compute_sg.id]

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -203,7 +203,7 @@ data "aws_ami" "ubuntu" {
 
 # bastion 서버(EC2) 생성
 resource "aws_instance" "bastion" {
-  ami                         = data.aws_ami.ubuntu.id
+  ami                         = "ami-00e557080ac814181"
   instance_type               = "t2.micro"
   subnet_id                   = aws_subnet.net.id
   vpc_security_group_ids      = [aws_security_group.bastion_sg.id]
@@ -305,8 +305,6 @@ resource "aws_lb_target_group_attachment" "bastion" {
   target_group_arn = aws_lb_target_group.alb_target_group.arn
   target_id        = aws_instance.bastion.id
   port             = 80
-
-
 }
 
 # 개발 환경 - bastion 호스트 연결

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -290,7 +290,7 @@ resource "aws_lb_target_group" "alb_target_group" {
 
   health_check {
     enabled             = true
-    interval            = 30
+    interval            = 300
     path                = "/v3/api-docs"
     port                = "traffic-port"
     healthy_threshold   = 2


### PR DESCRIPTION
## 작업 이유

- close #10 

<br/>

## 작업 사항

- bastion 및 was 호스트의 AMI 고정값으로 변경
- elb의 health check 주기를 30초 -> 300초으로 변경
  - 기존 대면 회의에서는 1시간(3600초)으로 하기로 하였으나 최대 값이 300초임
    <img width="808" alt="image" src="https://github.com/CollaBu/pennyway-iac/assets/68031450/659fc757-a6fd-4dec-9301-3a15b58545f9">

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- 없음

<br/>

## 발견한 이슈

- AMI를 동적으로 선언하여 새로운 버전의 AMI가 검색되는 상황 발생 => AMI를 고정값으로 치환