### PR TITLE
✨ S3 구축 및 도메인 설정

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,14 +7,16 @@ provider "aws" {
 
 # VPC, Subnet 등 네트워크 환경 구축
 module "network" {
-  source         = "./modules/network"
-  cidr_block     = var.cidr_block
-  region_name    = var.region_name
-  env_name       = var.env_name_dev
-  terraform_name = var.terraform_name
-  keypair        = var.keypair
-  remote_ip      = var.remote_ip
-  domain         = var.domain
+  source                  = "./modules/network"
+  cidr_block              = var.cidr_block
+  region_name             = var.region_name
+  env_name                = var.env_name_dev
+  terraform_name          = var.terraform_name
+  keypair                 = var.keypair
+  remote_ip               = var.remote_ip
+  domain                  = var.domain
+  bucket_website_endpoint = module.storage.bucket_website_endpoint
+  bucket_zone_id          = module.storage.bucket_zone_id
 }
 
 # was 서버 구축

--- a/main.tf
+++ b/main.tf
@@ -36,3 +36,10 @@ module "amplify_web" {
   source              = "./modules/amplify_web"
   github_access_token = var.github_access_token
 }
+
+# S3 버킷 구축
+module "storage" {
+  source   = "./modules/storage"
+  env_name = var.env_name_dev
+  domain   = var.domain
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -320,6 +320,19 @@ resource "aws_route53_record" "dev_to_bastion" {
   }
 }
 
+# 개발 환경 - Storage(S3) 연결
+resource "aws_route53_record" "dev_to_storage" {
+  zone_id = aws_route53_zone.zone_dev.zone_id
+  name    = "s3.dev.${var.domain}"
+  type    = "A"
+
+  alias {
+    name                   = var.bucket_website_endpoint
+    zone_id                = var.bucket_zone_id
+    evaluate_target_health = false
+  }
+}
+
 # 개발 도메인 인증서 생성
 resource "aws_acm_certificate" "cert_dev" {
   domain_name       = "*.dev.${var.domain}"

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -32,3 +32,13 @@ variable "remote_ip" {
 variable "domain" {
   type = string
 }
+
+# S3 버킷 엔드포인트
+variable "bucket_website_endpoint" {
+  type = string
+}
+
+# S3 웹사이트의 zone_id 
+variable "bucket_zone_id" {
+  type = string
+}

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,3 +1,48 @@
-resource "aws_s3_bucket" "storage" {
+# S3 버킷 리소스
+resource "aws_s3_bucket" "bucket" {
   bucket = "s3.${var.env_name}.${var.domain}"
+}
+
+# S3 버킷의 Public Access Block 설정
+resource "aws_s3_bucket_public_access_block" "example" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+# S3 버킷 접근 제어 정책 설정
+resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
+}
+
+# 다른 계정에서 S3 버킷에 접근할 수 있도록 권한 설정
+data "aws_iam_policy_document" "allow_access_from_another_account" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.bucket.arn,
+      "${aws_s3_bucket.bucket.arn}/*",
+    ]
+  }
+}
+
+# S3 버킷 정적 웹사이트 호스팅 설정
+resource "aws_s3_bucket_website_configuration" "website_config" {
+  bucket = aws_s3_bucket.bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
 }

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "storage" {
+  bucket = "s3.${var.env_name}.${var.domain}"
+}

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -1,0 +1,9 @@
+# S3 버킷 엔드포인트
+output "bucket_website_endpoint" {
+  value = aws_s3_bucket_website_configuration.website_config.website_domain
+}
+
+# S3 웹사이트의 zone_id 
+output "bucket_zone_id" {
+  value = aws_s3_bucket.bucket.hosted_zone_id
+}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,0 +1,9 @@
+# 리소스명에서 참조되는 env_name(prod, dev, etc.)
+variable "env_name" {
+  type = string
+}
+
+# 서비스 도메인
+variable "domain" {
+  type = string
+}


### PR DESCRIPTION
## 작업 이유

정적 파일 저장을 위한 AWS S3 서비스 필요성 대두

<br/>

## 작업 사항

- AWS S3 리소스 생성
  - S3 정책 설정
- AWS S3 도메인 설정 (`s3.dev.pennyway.co.kr`)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- 기존 S3 객체 접근 시 URL : [`https://s3.ap-northeast-2.amazonaws.com/s3.dev.pennyway.co.kr/profile.jpg`](https://s3.ap-northeast-2.amazonaws.com/s3.dev.pennyway.co.kr/profile.jpg)
- 도메인 적용 예시 : [`http://s3.dev.pennyway.co.kr/profile.jpg](http://s3.dev.pennyway.co.kr/profile.jpg`)
  - 추후 폴더 생성 시 예시 : `http://s3.dev.pennyway.co.kr/profile/xxx.jpg`
  - 현재 **도메인 적용 여부 판별을 위해** 설정한 것이고, cloud-front 구축 작업을 시작하면서 public access를 허용하지 않을 계획입니다. 따라서 S3 정책이 수정될 수 있습니다.
	<img width="484" alt="image" src="https://github.com/CollaBu/pennyway-iac/assets/68031450/19e29892-22a5-4d55-b249-dc01671dbdaf">

<br/>

## 발견한 이슈

- 이전에 재서님(@psychology50)이 말씀해주셨던 대로 `network` 모듈의 크기가 점점 커지고 있음을 느끼고 있습니다.
  - 이에 따라 `domain` 모듈을 생성하여 분리할 계획을 가지고 있습니다.