### PR TITLE
✨ 정적 파일 조회를 위한 AWS CloudFront 리소스 생성 및 도메인 설정

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,8 @@ module "network" {
   domain                  = var.domain
   bucket_website_endpoint = module.storage.bucket_website_endpoint
   bucket_zone_id          = module.storage.bucket_zone_id
+  cdn_domain_name         = module.storage.cdn_domain_name
+  cdn_zone_id             = module.storage.cdn_zone_id
 }
 
 # was 서버 구축
@@ -41,7 +43,8 @@ module "amplify_web" {
 
 # S3 버킷 구축
 module "storage" {
-  source   = "./modules/storage"
-  env_name = var.env_name_dev
-  domain   = var.domain
+  source          = "./modules/storage"
+  env_name        = var.env_name_dev
+  domain          = var.domain
+  certificate_arn = module.network.cert_cdn_arn
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -32,3 +32,8 @@ output "bastion_cidr" {
 output "bastion_ip" {
   value = aws_instance.bastion.public_ip
 }
+
+# CDN 개발 환경 인증서 arn
+output "cert_cdn_arn" {
+  value = aws_acm_certificate.cert_dev_cdn.arn
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -42,3 +42,13 @@ variable "bucket_website_endpoint" {
 variable "bucket_zone_id" {
   type = string
 }
+
+# CDN의 domain_name
+variable "cdn_domain_name" {
+  type = string
+}
+
+# CDN의 zone_id
+variable "cdn_zone_id" {
+  type = string
+}

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -80,6 +80,10 @@ resource "aws_cloudfront_distribution" "s3_cdn" {
   is_ipv6_enabled = true
   comment         = "CDN for my S3 bucket"
 
+  aliases = [
+    "cdn.${var.env_name}.${var.domain}",
+  ]
+
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
@@ -94,6 +98,7 @@ resource "aws_cloudfront_distribution" "s3_cdn" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
+    max_ttl                = 43200 # 12 hours
   }
 
   restrictions {
@@ -103,6 +108,8 @@ resource "aws_cloudfront_distribution" "s3_cdn" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn      = var.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2018"
   }
 }

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 # S3 버킷의 Public Access Block 설정
-resource "aws_s3_bucket_public_access_block" "aws_s3_bucket_policy" {
+resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
   bucket = aws_s3_bucket.bucket.id
 
   block_public_acls       = true

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -16,7 +16,21 @@ resource "aws_s3_bucket_public_access_block" "example" {
 # S3 버킷 접근 제어 정책 설정
 resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
   bucket = aws_s3_bucket.bucket.id
-  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          "AWS" = "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${aws_cloudfront_origin_access_identity.oai.id}"
+        }
+        Action = "s3:GetObject"
+        Resource = [
+          "${aws_s3_bucket.bucket.arn}/*"
+        ]
+      }
+    ]
+  })
 }
 
 # 다른 계정에서 S3 버킷에 접근할 수 있도록 권한 설정

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -46,3 +46,47 @@ resource "aws_s3_bucket_website_configuration" "website_config" {
     suffix = "index.html"
   }
 }
+
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "OAI for my S3 bucket"
+}
+
+resource "aws_cloudfront_distribution" "s3_cdn" {
+  origin {
+    domain_name = aws_s3_bucket.bucket.bucket_regional_domain_name
+    origin_id   = aws_s3_bucket.bucket.arn
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "CDN for my S3 bucket"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = aws_s3_bucket.bucket.arn
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -61,10 +61,12 @@ resource "aws_s3_bucket_website_configuration" "website_config" {
   }
 }
 
+# S3 버킷에 CDN 설정을 위한 Origin Access Identity 생성
 resource "aws_cloudfront_origin_access_identity" "oai" {
   comment = "OAI for my S3 bucket"
 }
 
+# S3 버킷에 대한 CDN 리소스 생성
 resource "aws_cloudfront_distribution" "s3_cdn" {
   origin {
     domain_name = aws_s3_bucket.bucket.bucket_regional_domain_name

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -7,10 +7,10 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_public_access_block" "example" {
   bucket = aws_s3_bucket.bucket.id
 
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 # S3 버킷 접근 제어 정책 설정

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 # S3 버킷의 Public Access Block 설정
-resource "aws_s3_bucket_public_access_block" "example" {
+resource "aws_s3_bucket_public_access_block" "aws_s3_bucket_policy" {
   bucket = aws_s3_bucket.bucket.id
 
   block_public_acls       = true

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -7,3 +7,13 @@ output "bucket_website_endpoint" {
 output "bucket_zone_id" {
   value = aws_s3_bucket.bucket.hosted_zone_id
 }
+
+# CDN의 domain_name
+output "cdn_domain_name" {
+  value = aws_cloudfront_distribution.s3_cdn.domain_name
+}
+
+# CDN의 zone_id
+output "cdn_zone_id" {
+  value = aws_cloudfront_distribution.s3_cdn.hosted_zone_id
+}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -7,3 +7,8 @@ variable "env_name" {
 variable "domain" {
   type = string
 }
+
+# 인증서 arn
+variable "certificate_arn" {
+  type = string
+}


### PR DESCRIPTION
## 작업 이유

- 사용자 프로필 이미지, 피드 이미지 등 정적 파일을 캐싱하기 위한 CDN 리소스 필요성 대두

<br/>

## 작업 사항

- S3 접근 정책 수정 : CDN을 통한 접근 허용
- CloudFront 리소스 생성
- CloudFront에 자체 도메인 적용을 위한 `us-east-1` ACM 인증서 발급

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- S3 직접 접근 불가능 확인 : [http://s3.dev.pennyway.co.kr/profile.jpg](http://s3.dev.pennyway.co.kr/profile.jpg)
- CloudFront를 위한 정적 파일 접근 확인 : [https://cdn.dev.pennyway.co.kr/profile.jpg](https://cdn.dev.pennyway.co.kr/profile.jpg)


<br/>

## 발견한 이슈

- CloudFront에 자체 도메인 적용을 위한 `us-east-1` ACM 인증서 발급 이유 : [https://jinlee.kr/devops/2024-05-20-cloudfront-domain-setting/](https://jinlee.kr/devops/2024-05-20-cloudfront-domain-setting/)