### PR TITLE
✨ 임시 이미지 삭제를 위한 s3 lifecycle 설정

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -113,3 +113,22 @@ resource "aws_cloudfront_distribution" "s3_cdn" {
     minimum_protocol_version = "TLSv1.2_2018"
   }
 }
+
+# S3 버킷 Lifecycle 설정
+resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    id = "delete-rule"
+
+    filter {
+      prefix = "delete/"
+    }
+
+    status = "Enabled"
+
+    expiration {
+      days = 2
+    }
+  }
+}


### PR DESCRIPTION
## 작업 이유

- 클라이언트(iOS)에서 이미지 등록 시 임시 이미지(`delete/`) 저장이 이루어지는데, 이러한 임시 이미지의 정기적 삭제 필요성 대두

<br/>

## 작업 사항

- S3 lifecycle 설정 : prefix(`delete/`) filtering을 통해 해당 경로의 파일이 저장된 지 2일 후 삭제

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

<img width="1764" alt="image" src="https://github.com/CollaBu/pennyway-iac/assets/68031450/40ecb67d-acbf-40a4-80f3-4f26bd4c9665">

<br/>

## 발견한 이슈

- 없음