### PR TITLE
✨ RDS 구축 및 연결

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,3 +57,17 @@ module "lambda" {
   layer         = "lambda_layers/image_resizer.zip"
   bucket        = module.storage.bucket
 }
+
+# RDS 구축
+module "rds" {
+  source         = "./modules/rds"
+  vpc_id         = module.network.vpc_id
+  region_name    = var.region_name
+  terraform_name = var.terraform_name
+  env_name       = var.env_name_dev
+  db_username    = var.db_username
+  db_password    = var.db_password
+  app_cidr_block = module.network.app_cidr_block
+  subnet_id_1    = module.network.data_subnet_id_1
+  subnet_id_2    = module.network.data_subnet_id_2
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -37,3 +37,18 @@ output "bastion_ip" {
 output "cert_cdn_arn" {
   value = aws_acm_certificate.cert_dev_cdn.arn
 }
+
+# RDS 접속을 위한 CIDR block
+output "app_cidr_block" {
+  value = aws_subnet.app.cidr_block
+}
+
+# RDS 서브넷 그룹을 위한 subnet id 1
+output "data_subnet_id_1" {
+  value = aws_subnet.data1.id
+}
+
+# RDS 서브넷 그룹을 위한 subnet id 2
+output "data_subnet_id_2" {
+  value = aws_subnet.data2.id
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,63 @@
+# rds security-group 정의
+resource "aws_security_group" "rds_sg" {
+  vpc_id = var.vpc_id
+
+  tags = {
+    Name = "${var.region_name}-${var.terraform_name}-${var.env_name}-rds-sg"
+  }
+}
+
+# bastion 서버에서 net 서브넷에서 오는 접근 허용
+resource "aws_security_group_rule" "app_inbound_ssh" {
+  type              = "ingress"
+  from_port         = 3306
+  to_port           = 3306
+  protocol          = "tcp"
+  cidr_blocks       = [var.app_cidr_block]
+  security_group_id = aws_security_group.rds_sg.id
+}
+
+# rds 서버에서 app 서브넷에서 오는 접근 허용
+resource "aws_security_group_rule" "data_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.rds_sg.id
+}
+
+# rds subnet group 정의
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name       = "${var.terraform_name}-rds-subnet-group"
+  subnet_ids = [var.subnet_id_1, var.subnet_id_2]
+
+  tags = {
+    Name = "${var.region_name}-${var.terraform_name}-${var.env_name}-rds-subnet-group"
+  }
+}
+
+
+# rds 리소스 정의
+resource "aws_db_instance" "rds" {
+  availability_zone     = "ap-northeast-2a"
+  identifier            = "${var.terraform_name}-${var.env_name}-rdb"
+  engine                = "mysql"
+  engine_version        = "8.0"
+  instance_class        = "db.t3.micro"
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp2"
+  username              = var.db_username
+  password              = var.db_password
+  parameter_group_name  = "default.mysql8.0"
+  skip_final_snapshot   = true
+  publicly_accessible   = true
+
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name   = aws_db_subnet_group.rds_subnet_group.name
+
+  tags = {
+    Name = "${var.region_name}-${var.terraform_name}-${var.env_name}-rds"
+  }
+}

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,4 @@
+# 데이터베이스 호스트
+output "db_host" {
+  value = aws_db_instance.rds.address
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,45 @@
+# vpc
+variable "vpc_id" {
+  type = string
+}
+
+# 리소스명에서 참조되는 region_name
+variable "region_name" {
+  type = string
+}
+
+# 리소스명에서 참조되는 terraform_name(서비스명)
+variable "terraform_name" {
+  type = string
+}
+
+# 리소스명에서 참조되는 환경명
+variable "env_name" {
+  type = string
+}
+
+# DB에 접근하기 위한 username
+variable "db_username" {
+  type = string
+}
+
+# DB에 접근하기 위한 password
+variable "db_password" {
+  type = string
+}
+
+# rdb에 접근 가능한 ip
+variable "app_cidr_block" {
+  type = string
+}
+
+# rds 서브넷 그룹을 위한 subnet id 1
+variable "subnet_id_1" {
+  description = "ID of the first subnet for RDS"
+  type        = string
+}
+# rds 서브넷 그룹을 위한 subnet id 2
+variable "subnet_id_2" {
+  description = "ID of the second subnet for RDS"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,13 @@ variable "domain" {
 variable "github_access_token" {
   type = string
 }
+
+# DB 접근을 위한 username
+variable "db_username" {
+  type = string
+}
+
+# DB 접근을 위한 password
+variable "db_password" {
+  type = string
+}


### PR DESCRIPTION
## 작업 이유

- 서비스 운영을 위해 DB 안정성 향상을 위한 RDS 구축 및 연결 필요성 대두

<br/>

## 작업 사항

- RDS 모듈 정의
- `docker-compose.yml`에 rdb block 삭제
- `.env`에 db host 수정

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- notion의 db host 및 db 주소 참고하면, MySQL Workbench 및 Intellij를 통한 Local 환경에서 RDS 접속 가능합니다.

<br/>

## 발견한 이슈

- rds에 subnet을 두 개 이상 연결(`aws_db_subnet_group.rds_subnet_group`)한 이유는 rds 생성 시에 최소 두 개 이상의 subnet 설정을 해야 리소스 생성이 가능합니다.