### PR TITLE
✨ RDS Parameter Group 추가

### DIFF
--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -88,9 +88,4 @@ resource "aws_db_parameter_group" "rds_parameter" {
     name  = "character_set_server"
     value = "utf8mb4"
   }
-
-  tags = {
-    Environment = var.env_name
-    Terraform   = "true"
-  }
 }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -53,14 +53,14 @@ resource "aws_db_instance" "rds" {
   availability_zone     = "ap-northeast-2a"
   identifier            = "${var.terraform_name}-${var.env_name}-rdb"
   engine                = "mysql"
-  engine_version        = "8.0"
+  engine_version        = "8.0.35"
   instance_class        = "db.t3.micro"
   allocated_storage     = 20
   max_allocated_storage = 100
   storage_type          = "gp2"
   username              = var.db_username
   password              = var.db_password
-  parameter_group_name  = "default.mysql8.0"
+  parameter_group_name  = aws_db_parameter_group.rds_parameter.name
   skip_final_snapshot   = true
   publicly_accessible   = true
 
@@ -72,3 +72,25 @@ resource "aws_db_instance" "rds" {
   }
 }
 
+# rds 파라미터 정의
+resource "aws_db_parameter_group" "rds_parameter" {
+  name = "rds-pg-${var.env_name}"
+  family = "mysql8.0.35"
+  description = "MySQL 8.0.35 Custom Parameter Group"
+
+  parameter {
+    name = "innodb_ft_min_token_size"
+    value = "2"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  tags = {
+    Environment = var.env_name
+    Terraform   = "true"
+  }
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -75,8 +75,8 @@ resource "aws_db_instance" "rds" {
 # rds 파라미터 정의
 resource "aws_db_parameter_group" "rds_parameter" {
   name = "rds-pg-${var.env_name}"
-  family = "mysql8.0.35"
-  description = "MySQL 8.0.35 Custom Parameter Group"
+  family = "mysql8.0"
+  description = "MySQL 8.0 Custom Parameter Group"
 
   parameter {
     name = "innodb_ft_min_token_size"


### PR DESCRIPTION
## 작업 이유
- MySQL `innodb_ft_min_token_size`를 4(default)에서 2로 수정할 필요성 존재
- 런타임에서 변수값만 수정하려 했으나, 반드시 재실행이 수반되어야 반영되는 파라미터
- 그러나 AWS RDS를 사용하고 있는 관계로, 부득이하게 terraform을 사용하여 설정을 변경함.

<br/>

## 작업 사항
- rds parameter를 추가해, "innodb_ft_min_token_size" 속성을 2로 수정함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 이 외 다른 것들은 일절 건들지 않았고, rds parameter만 부분적인 apply를 위해 필수로 알아야 하는 state들은 import로 값을 불러왔습니다.
- 설정은 공식 문서 참고해서, 필요한 설정만 수정해놨습니다.

![image](https://github.com/user-attachments/assets/a7498805-2acb-4103-ad42-90bef9ffcc7e)

- 변경 사항 확인 완료.

<br/>

## 발견한 이슈
- 어제까지 vpn으로 db 접근이 안 되던 문제가 있었으나, 오늘 해결하려고 보니 갑자기 다시 잘 됨.
- network 쪽은 건든 게 없는데, 혹시 몰라서 장애 발생 지점 파악 중에 있습니다.
   - 지금은 너무 잘 돼서 아마 확인은 어렵겠지만, 이전에 확인했던 부분들.
      - Bastion -> RDS: ✅
      - VPN -> Bastion: ✅
      - VPN -> RDS: ??? (확인 못함)